### PR TITLE
Fix library version when linked with sbt via github url

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "Scrava"
 
 organization := "kiambogo"
 
-version := "git describe --dirty --tags --always".!!.stripPrefix("v").trim
+version := Process("git describe --dirty --tags --always", baseDirectory.value).!!.stripPrefix("v").trim
 
 scalaVersion := "2.11.8"
 


### PR DESCRIPTION
This change fixes a problem found when including the Scrava library into a parent project
via the github url using a project/Build.scala file. (utilising the dependsOn sbt command)

When included this way during the sbt build process the git describe command is run from
the project root directory, not the Scrava library location. Consequently the git command
fails if the parent project is not a git repo. If the parent is a git repo I assume it
will return the version of the parent project instead of the Scrava project.

The change ensures the git command is run from the Scrava project location, not the
parent project.